### PR TITLE
fix: generate artifact only on output dir (close #18)

### DIFF
--- a/packer/packer.go
+++ b/packer/packer.go
@@ -13,7 +13,7 @@ import (
 
 type Packer interface {
 	Prep() error
-	Build() ([]string, error)
+	Build(outputDir string) ([]string, error)
 	Install() error
 	Update() error
 }

--- a/pacman/pacman.go
+++ b/pacman/pacman.go
@@ -274,14 +274,19 @@ func (p *Pacman) clean() (err error) {
 	return
 }
 
-func (p *Pacman) copy() (err error) {
+func (p *Pacman) copy(destination string) (err error) {
 	pkgs, err := utils.FindExt(p.pacmanDir, ".pkg.tar.zst")
 	if err != nil {
 		return
 	}
 
 	for _, pkg := range pkgs {
-		err = utils.CopyFile("", pkg, p.Pack.Home, false)
+		pkgDestination := filepath.Join(p.Pack.Home, destination)
+		err = utils.ExistsMakeDir(pkgDestination)
+		if err != nil {
+			return
+		}
+		err = utils.CopyFile("", pkg, pkgDestination, false)
 		if err != nil {
 			return
 		}
@@ -294,7 +299,7 @@ func (p *Pacman) remDirs() {
 	os.RemoveAll(p.pacmanDir)
 }
 
-func (p *Pacman) Build() ([]string, error) {
+func (p *Pacman) Build(outputDir string) ([]string, error) {
 	err := p.makeDirs()
 	if err != nil {
 		return nil, err
@@ -317,7 +322,7 @@ func (p *Pacman) Build() ([]string, error) {
 		return nil, err
 	}
 
-	err = p.copy()
+	err = p.copy(outputDir)
 	if err != nil {
 		return nil, err
 	}

--- a/pacman/pacman.go
+++ b/pacman/pacman.go
@@ -282,10 +282,12 @@ func (p *Pacman) copy(destination string) (err error) {
 
 	for _, pkg := range pkgs {
 		pkgDestination := filepath.Join(p.Pack.Home, destination)
+
 		err = utils.ExistsMakeDir(pkgDestination)
 		if err != nil {
 			return
 		}
+
 		err = utils.CopyFile("", pkg, pkgDestination, false)
 		if err != nil {
 			return

--- a/project/project.go
+++ b/project/project.go
@@ -168,22 +168,8 @@ func (m *MultipleProject) BuildAll() error {
 			return err
 		}
 
-		artefactPaths, err := proj.Packer.Build()
-		if err != nil {
+		if _, err := proj.Packer.Build(m.output); err != nil {
 			return err
-		}
-
-		if m.output != "" {
-			if err := utils.ExistsMakeDir(m.output); err != nil {
-				return err
-			}
-
-			for _, ap := range artefactPaths {
-				filename := filepath.Base(ap)
-				if err := utils.Copy("", ap, filepath.Join(m.output, filename), false); err != nil {
-					return err
-				}
-			}
 		}
 
 		if proj.HasToInstall {

--- a/redhat/redhat.go
+++ b/redhat/redhat.go
@@ -280,7 +280,7 @@ func (r *Redhat) clean() (err error) {
 	return
 }
 
-func (r *Redhat) copy() (err error) {
+func (r *Redhat) copy(destination string) (err error) {
 	archs, err := ioutil.ReadDir(r.rpmsDir)
 	if err != nil {
 		fmt.Printf("redhat: Failed to find rpms from '%s'\n",
@@ -290,10 +290,15 @@ func (r *Redhat) copy() (err error) {
 	}
 
 	for _, arch := range archs {
+		rpmDestination := filepath.Join(r.Pack.Home, destination)
+		err = utils.ExistsMakeDir(rpmDestination)
+		if err != nil {
+			return
+		}
 		err = utils.CopyFiles(filepath.Join(
 			r.rpmsDir,
 			arch.Name(),
-		), r.Pack.Home, false)
+		), rpmDestination, false)
 		if err != nil {
 			return
 		}
@@ -306,7 +311,7 @@ func (r *Redhat) remDirs() {
 	os.RemoveAll(r.redhatDir)
 }
 
-func (r *Redhat) Build() ([]string, error) {
+func (r *Redhat) Build(outputDir string) ([]string, error) {
 	err := r.makeDirs()
 	if err != nil {
 		return nil, err
@@ -334,7 +339,7 @@ func (r *Redhat) Build() ([]string, error) {
 		return nil, err
 	}
 
-	err = r.copy()
+	err = r.copy(outputDir)
 	if err != nil {
 		return nil, err
 	}

--- a/redhat/redhat.go
+++ b/redhat/redhat.go
@@ -291,10 +291,12 @@ func (r *Redhat) copy(destination string) (err error) {
 
 	for _, arch := range archs {
 		rpmDestination := filepath.Join(r.Pack.Home, destination)
+
 		err = utils.ExistsMakeDir(rpmDestination)
 		if err != nil {
 			return
 		}
+
 		err = utils.CopyFiles(filepath.Join(
 			r.rpmsDir,
 			arch.Name(),


### PR DESCRIPTION
This solves #18.
Artifact was generated both on the PKGBUILD
dir and the output directory. Now only the
latter is generated.