### PR TITLE
chore: go-templates: use CUSTOM license if field is missing (for apk …

### DIFF
--- a/apk/constants.go
+++ b/apk/constants.go
@@ -25,7 +25,7 @@ install={{.Pack.PkgName}}.install
 {{- if .Pack.License}}
 license={{.Pack.License}}
 {{- else }}
-license="MIT"
+license="CUSTOM"
 {{- end }}
 
 options="!check !fhs"

--- a/redhat/constants.go
+++ b/redhat/constants.go
@@ -10,8 +10,10 @@ Group: {{.Pack.Section}}
 {{- if .Pack.URL}}
 URL: {{.Pack.URL}}
 {{- end }}
-{{- with .Pack.License}}
+{{- if .Pack.License}}
 License: {{join .}}
+{{- else }}
+License: CUSTOM
 {{- end }}
 {{- if .Pack.Maintainer}}
 Packager: {{.Pack.Maintainer}}


### PR DESCRIPTION
…and rpm)